### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,6 +23,7 @@ on:
 jobs:
 
   build-arch-Linux-environment:
+    permissions: none
     runs-on: ubuntu-latest
     container:
       image: archlinux:latest


### PR DESCRIPTION
Potential fix for [https://github.com/UocDev/Tachyon/security/code-scanning/1](https://github.com/UocDev/Tachyon/security/code-scanning/1)

To fix the problem, add a `permissions` block to the `build-arch-Linux-environment` job in `.github/workflows/codeql.yml` to limit the permissions of the GITHUB_TOKEN used in the job. The minimum safe permission for jobs that do not interact with the repository or GitHub API is `none`. This block needs to be inserted directly under the job name and above the `runs-on` key. No new imports or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
