### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,6 +24,7 @@ jobs:
 
   setup-ubuntu:
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
        - name: Fetching updates
          run: sudo apt update -y


### PR DESCRIPTION
Potential fix for [https://github.com/UocDev/Tachyon/security/code-scanning/3](https://github.com/UocDev/Tachyon/security/code-scanning/3)

To correct the issue, add a `permissions` block to the `setup-ubuntu` job. Since the job merely updates system packages and does not interact with the repository, the minimal effective permissions are `none` (i.e., set `permissions: {}` or `permissions: none`). This ensures the job receives the least privilege possible, and addresses the CodeQL warning. The change should be made right after the `runs-on: ubuntu-latest` line within the `setup-ubuntu` job section of `.github/workflows/codeql.yml`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
